### PR TITLE
Changed Query for train_dataset None

### DIFF
--- a/vectory/db/models.py
+++ b/vectory/db/models.py
@@ -248,7 +248,9 @@ class Query(Generic[Q]):
             if "_path" in key:
                 condition[key] = os.path.abspath(condition[key])
 
-        condition = {k: v for k, v in condition.items() if v is not None}
+        condition = {
+            k: v for k, v in condition.items() if v is not None or k == "train_dataset"
+        }
 
         query = self.model.select()
         for column, value in condition.items():


### PR DESCRIPTION
Changed the `Query` class not to remove all None values from queries.
Experiments can have train_dataset=None, so for that particular case, it should only return the experiments that have None as value.