### PR TITLE
Added Python 3.11 to tests.yml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7.12", "3.8.10", "3.9.7"]
+        python-version: ["3.7.12", "3.8.10", "3.9.7", "3.11"]
         poetry-version: [1.2.0]
 
     steps:


### PR DESCRIPTION
Added Python 3.11 to test.yaml in order to support that version on the automated tests. I didn't specify which version within Python 3.11, but it could be changed to a preferred one.

Currently Vectory supports Python 3.7, 3.8, 3.9, 3.10.